### PR TITLE
Fix bytes string host

### DIFF
--- a/pybase/client.py
+++ b/pybase/client.py
@@ -382,6 +382,7 @@ class MainClient(object):
                 # hosted on.
                 server_loc = cell.value
                 host, port = cell.value.split(b':')
+                host = host.decode("utf-8")
             else:
                 continue
         # Do we have an existing client for this region server already?


### PR DESCRIPTION
This was preventing us from being able to upgrade gevent. It now enforces that the host must be a string-type, not a bytes string. I tested this & it's backwards compatible for py2 clients as well.