### PR TITLE
using a ThreadPoolExecutor to match socket pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+.idea

--- a/pybase/region/client.py
+++ b/pybase/region/client.py
@@ -162,14 +162,14 @@ class Client(object):
         sp = thread_name.split("_") # i.e. splitting "ThreadPoolExecutor-1_0"
         pool_id = int(sp[1]) # thread number is now responsible for only using its matching socket
 
-        client.sock_pool[pool_id].send(to_send)
-
         # If the field data is populated that means we should process from that
         # instead of the socket.
         full_data = None
         # Total message length is going to be the first four bytes
         # (little-endian uint32)
         try:
+            client.sock_pool[pool_id].send(to_send)
+
             msg_length = Client._recv_n(self.sock_pool[pool_id], 4)
             if msg_length is None:
                 raise

--- a/pybase/region/client.py
+++ b/pybase/region/client.py
@@ -143,7 +143,7 @@ class Client(object):
         to_send += serialized_header + rpc_length_bytes + serialized_rpc
 
         # send and receive the request
-        future = self.thread_pool.submit(Client.send_and_receive_rpc, [self, my_id, rq, to_send])
+        future = self.thread_pool.submit(self.send_and_receive_rpc, rq, to_send)
         return future.result()
 
     # Sending an RPC, listens for the response and builds the correct pbResponse object.
@@ -156,8 +156,8 @@ class Client(object):
     #   4. A varint representing the length of the serialized ResponseMessage.
     #   5. The ResponseMessage.
     #
-    @staticmethod
-    def send_and_receive_rpc(client, call_id, rq, to_send):
+    # @staticmethod
+    def send_and_receive_rpc(self, rq, to_send):
         thread_name = current_thread().name
         sp = thread_name.split("_") # i.e. splitting "ThreadPoolExecutor-1_0"
         pool_id = int(sp[1]) # thread number is now responsible for only using its matching socket
@@ -168,7 +168,7 @@ class Client(object):
         # Total message length is going to be the first four bytes
         # (little-endian uint32)
         try:
-            client.sock_pool[pool_id].send(to_send)
+            self.sock_pool[pool_id].send(to_send)
 
             msg_length = Client._recv_n(self.sock_pool[pool_id], 4)
             if msg_length is None:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from setuptools import find_packages, setup
 
 setup(name='pybase',
-      version='0.3.3',
+      version='4.0.0',
       description='Native python client to hbase 1.0+',
       url='https://github.com/CurleySamuel/PyBase',
       author='Sam Curley',


### PR DESCRIPTION
Instead of making multiple locks between sending and receiving insanity... why not just have a ThreadPoolExecutor with a number of threads equal to the socket pool size.  Then users of the Client can simply submit work, and open thread in the ThreadPool will simply do the work.  Each thread in a ThreadPoolExecutor has a unique number (say `ThreadPoolExecutor-1_0` where the last number is the thread number.  Simply use that number to decide which socket to use, and voilà, no more contention for a socket.

I'll test this Monday.